### PR TITLE
Formalize extended attribute xml chars

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,7 @@ jobs:
       
       # Build with Maven
       - name: Build
-        run: mvn --batch-mode install -DskipTests
+        run: mvn --batch-mode install assembly:single -DskipTests
         working-directory: ./PowerDeComposer
 
       # Test with Maven
@@ -52,12 +52,6 @@ jobs:
           name: test-results-${{ matrix.os }}-java-${{ matrix.java }}
           path: PowerDeComposer/target/surefire-reports/TEST-*.xml
           reporter: java-junit
-
-      # Build single jar
-      - name: Assemble Jar
-        if: runner.os == 'Linux'
-        run: mvn --batch-mode assembly:single -DskipTests
-        working-directory: ./PowerDeComposer
 
       # Publish jars.
       - uses: actions/upload-artifact@v4

--- a/Documentation/docs/ReleaseNotes.md
+++ b/Documentation/docs/ReleaseNotes.md
@@ -22,6 +22,17 @@ Click on the header of a version number to go to the documentation of that speci
 
 ## Version 1.6.0
 
+- [ ] 1.6.1 <sup>08-08-2024</sup>
+> !!! warning "Bug fixes"
+>     * [ ] Decompose model
+>         - [X] Fixed new-line handling so line endings are not accidentally converted.
+>         - [X] Fixed special characters and new-line handling for formalized attributes.
+>         - [X] Corrected formalize extended attributes naming in config.
+>     * [ ] Compose model
+>         - [X] Fixed special characters and new-line handling for deformalizing attributes.
+>     * [ ] General
+>         - [X] Setting correct exit code (1) when an error occured when running PowerDeComposer.
+
 - [ ] 1.6.0 <sup>02-08-2023</sup>
 > !!! success "Enhanced features"
 >     * [ ] Decompose model

--- a/PowerDeComposer/pom.xml
+++ b/PowerDeComposer/pom.xml
@@ -108,6 +108,12 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.11.0</version>
 		</dependency>
+		<!-- Apache Commons Text for XML escape/unescaping. -->
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>1.11.0</version>
+		</dependency>
 		<!-- JAX-B for the config. -->
 		<dependency>
 			<groupId>jakarta.xml.bind</groupId>

--- a/PowerDeComposer/src/main/java/com/xbreeze/xml/Executor.java
+++ b/PowerDeComposer/src/main/java/com/xbreeze/xml/Executor.java
@@ -43,7 +43,7 @@ public class Executor {
 	 * @param args
 	 * @throws Exception
 	 */
-	public static void main(String[] args) throws Exception {
+	public static void main(String[] args) {
 		
 		// Setup the global LogManager.
 		LogManager logManager = LogManager.getLogManager();
@@ -70,34 +70,41 @@ public class Executor {
 		logger.setUseParentHandlers(false);
 		
 		// Check the passed arguments.
-		if (args.length == 3 || args.length == 4) {
-			String operationType = args[0];
-			
-			// Parse the config.
-			PowerDeComposerConfig pdcConfig;
-			if (args.length == 4) {
-				pdcConfig = PowerDeComposerConfig.fromFile(Paths.get(args[3]).toFile());
-			}
-			else {
-				// Create the default PowerDeComposerConfig.
-				pdcConfig = PowerDeComposerConfig.GetDefaultConfig();
-			}
-			
-			// Perform the operation. 
-			if (operationType.equalsIgnoreCase("decompose")) {
-				String xmlFilePath = args[1].trim();
-				String targetDirectory = args[2].trim();
-				new XmlDecomposer(xmlFilePath, targetDirectory, pdcConfig.getDecomposeConfig());
-			} else
-				if (operationType.equalsIgnoreCase("compose")) {
-					String xmlSourceFile = args[1].trim();
-					String xmlTargetFile = args[2].trim();
-					new XmlComposer(xmlSourceFile, xmlTargetFile);
-				} else {
-					throw new Exception("First argument should be compose or decompose");
+		try {
+			if (args.length == 3 || args.length == 4) {
+				String operationType = args[0];
+				
+				// Parse the config.
+				PowerDeComposerConfig pdcConfig;
+				if (args.length == 4) {
+					pdcConfig = PowerDeComposerConfig.fromFile(Paths.get(args[3]).toFile());
 				}
-		} else {
-			throw new Exception("Expecting exactly 3 or 4 arguments: (decompose, xml-file-path, target-directory[, config-file-location]) or (compose, xml-source-file, xml-target-file[, config-file-location]).");
+				else {
+					// Create the default PowerDeComposerConfig.
+					pdcConfig = PowerDeComposerConfig.GetDefaultConfig();
+				}
+				
+				// Perform the operation. 
+				if (operationType.equalsIgnoreCase("decompose")) {
+					String xmlFilePath = args[1].trim();
+					String targetDirectory = args[2].trim();
+					new XmlDecomposer(xmlFilePath, targetDirectory, pdcConfig.getDecomposeConfig());
+				} else
+					if (operationType.equalsIgnoreCase("compose")) {
+						String xmlSourceFile = args[1].trim();
+						String xmlTargetFile = args[2].trim();
+						new XmlComposer(xmlSourceFile, xmlTargetFile);
+					} else {
+						throw new Exception("First argument should be compose or decompose");
+					}
+			} else {
+				throw new Exception("Expecting exactly 3 or 4 arguments: (decompose, xml-file-path, target-directory[, config-file-location]) or (compose, xml-source-file, xml-target-file[, config-file-location]).");
+			}
+		} catch (Exception e) {
+			System.err.println("An error ocurred while running PowerDeComposer: ");
+			System.err.print(e.getMessage());
+			// Exit java with exit-code 1, so other processes can detect something went wrong.
+			System.exit(1);
 		}
 	}
 }

--- a/PowerDeComposer/src/main/java/com/xbreeze/xml/compose/XmlComposer.java
+++ b/PowerDeComposer/src/main/java/com/xbreeze/xml/compose/XmlComposer.java
@@ -122,7 +122,8 @@ public class XmlComposer {
 					
 					// Create a string buffer for the extended attribute text.
 					StringBuffer extendedAttributeText = new StringBuffer();
-					extendedAttributeText.append("\r\n<a:ExtendedAttributesText>");
+					extendedAttributeText.append(xmlFileContentsAndCharset.getLineSeparator());
+					extendedAttributeText.append("<a:ExtendedAttributesText>");
 					
 					// Find the OriginatingExtension elements.
 					AutoPilot ap_extension = new AutoPilot(nav);
@@ -146,9 +147,10 @@ public class XmlComposer {
 							String extAttrValue = new String(nav.getXML().getBytes(nav.getTokenOffset(extendedAttributeTextIndex), nav.getTokenLength(extendedAttributeTextIndex)));
 							// Add the current extended attribute to the list for the current extension.
 							// For the length we use the unescaped version of the extended attribute text.
-							extensionExtAttrTextBuffer.append(String.format("{%s},%s,%d=%s\r\n", extAttrObjectID, extAttrName, XMLUtils.unescapeXMLChars(extAttrValue).length(), extAttrValue));
+							extensionExtAttrTextBuffer.append(String.format("{%s},%s,%d=%s", extAttrObjectID, extAttrName, XMLUtils.unescapeXMLChars(extAttrValue).length(), extAttrValue));
+							extensionExtAttrTextBuffer.append(xmlFileContentsAndCharset.getLineSeparator());
 						}
-						extensionExtAttrTextBuffer.append("\r\n");
+						extensionExtAttrTextBuffer.append(xmlFileContentsAndCharset.getLineSeparator());
 						String extensionExtAttrText = extensionExtAttrTextBuffer.toString();
 						
 						// Add the extension extended attributes to the extended attributes buffer.

--- a/PowerDeComposer/src/main/java/com/xbreeze/xml/compose/XmlComposer.java
+++ b/PowerDeComposer/src/main/java/com/xbreeze/xml/compose/XmlComposer.java
@@ -142,16 +142,19 @@ public class XmlComposer {
 							String extAttrObjectID = nav.toString(nav.getAttrVal("ObjectID"));
 							String extAttrName = nav.toString(nav.getAttrVal("Name"));
 							// Replace a LF without preceding LF to CRLF (since VTD-NAV removed it during parsing).
-							String extAttrValue = nav.toString(nav.getText()).replaceAll("(?<!\r)\n", "\r\n");
+							int extendedAttributeTextIndex = nav.getText();
+							String extAttrValue = new String(nav.getXML().getBytes(nav.getTokenOffset(extendedAttributeTextIndex), nav.getTokenLength(extendedAttributeTextIndex)));
 							// Add the current extended attribute to the list for the current extension.
-							extensionExtAttrTextBuffer.append(String.format("{%s},%s,%d=%s\r\n", extAttrObjectID, extAttrName, extAttrValue.length(), extAttrValue));
+							// For the length we use the unescaped version of the extended attribute text.
+							extensionExtAttrTextBuffer.append(String.format("{%s},%s,%d=%s\r\n", extAttrObjectID, extAttrName, XMLUtils.unescapeXMLChars(extAttrValue).length(), extAttrValue));
 						}
 						extensionExtAttrTextBuffer.append("\r\n");
 						String extensionExtAttrText = extensionExtAttrTextBuffer.toString();
 						
 						// Add the extension extended attributes to the extended attributes buffer.
+						// For the length we use the unescaped version of the extended attribute text.
 						// The length is minus 2, to compensate for the trailing CRLF.
-						extendedAttributeText.append(String.format("{%s},%s,%d=%s", extObjectID, extName, extensionExtAttrText.length() - 2, extensionExtAttrText));
+						extendedAttributeText.append(String.format("{%s},%s,%d=%s", extObjectID, extName, XMLUtils.unescapeXMLChars(extensionExtAttrText).length() - 2, extensionExtAttrText));
 					}
 					extendedAttributeText.append("</a:ExtendedAttributesText>");
 					// Insert the ExtendedAttributesText element.
@@ -209,7 +212,7 @@ public class XmlComposer {
 				// otherwise return the original one
 				if (deformalizedExtendedAttributes || includeCount > 0) {
 					String resolvedXML = XMLUtils.getResultingXml(vm);
-					logger.fine(String.format("XML file %s with includes resolved:", xmlFile.toString()));
+					logger.fine(String.format("XML file %s with includes and formalized attributes resolved:", xmlFile.toString()));
 					logger.fine("**** Begin of XML file ****");
 					logger.fine(resolvedXML);
 					logger.fine("**** End of XML file ****");

--- a/PowerDeComposer/src/main/java/com/xbreeze/xml/decompose/XmlDecomposer.java
+++ b/PowerDeComposer/src/main/java/com/xbreeze/xml/decompose/XmlDecomposer.java
@@ -447,7 +447,11 @@ public class XmlDecomposer {
 			if (nv.getTokenType(extAttrsTextNodeIndex) == VTDNav.TOKEN_STARTING_TAG) {
 				// Get the extended attribute text.
 				// Replace LF with CRLF, since VTD-Nav removes the carriage returns in the file (and PowerDesigner always has CRLF).
-				String extendedAttributesText = nv.toString(nv.getText()).replace("\n", "\r\n");
+				int extendedAttributeTextIndex = nv.getText();
+				//String extendedAttributesText = nv.toString(extendedAttributeTextIndex).replace("\n", "\r\n");
+				String extendedAttributesText = new String(nv.getXML().getBytes(nv.getTokenOffset(extendedAttributeTextIndex), nv.getTokenLength(extendedAttributeTextIndex)));
+				// We unescape the XML characters here, so the length property in the extended attributes can be used (cause it doesn't account for escaped XML characters).
+				extendedAttributesText = XMLUtils.unescapeXMLChars(extendedAttributesText);
 				logger.fine(String.format("Found extended attributes text: %s", extendedAttributesText.replaceAll("\n", "[LF]\n").replaceAll("\r", "[CR]")));
 				
 				// The extended attribute text needs to be parsed so we can create the new XML elements.
@@ -473,7 +477,8 @@ public class XmlDecomposer {
 					if (extAttrsEnd > extendedAttributesText.length())
 						throw new Exception("Error while formalizing extended attributes text: The extended attribute length is longer then the contents of the string. This should never happen!");
 					
-					String extExtAttrContent = extendedAttributesText.substring(extAttrStart, extAttrsEnd);
+					// Get the extended attribute contents and escape XML chars, so we can make valid XML.
+					String extExtAttrContent = XMLUtils.escapeXMLChars(extendedAttributesText.substring(extAttrStart, extAttrsEnd));
 					
 					// If we are inside a extension section, so currentExtensionExtAttrEnd != -1. And we find a match where the the end index is after the end of extension section we have a problem.
 					// The end of an extension section should always be equal or after any child sections.
@@ -785,7 +790,7 @@ public class XmlDecomposer {
 				// Loop through the include attributes to add the min the include tag.
 				for (String includeAttributeName : includeAttributesWithValues.keySet()) {
 					// Insert the include sub element in the include tag.
-					includeElementStringBuffer.append(String.format(" %s=\"%s\"", includeAttributeName, XMLUtils.excapeXMLChars(includeAttributesWithValues.get(includeAttributeName))));				
+					includeElementStringBuffer.append(String.format(" %s=\"%s\"", includeAttributeName, XMLUtils.escapeXMLChars(includeAttributesWithValues.get(includeAttributeName))));				
 				}
 				includeElementStringBuffer.append(" />");
 				

--- a/PowerDeComposer/src/main/java/com/xbreeze/xml/decompose/XmlDecomposer.java
+++ b/PowerDeComposer/src/main/java/com/xbreeze/xml/decompose/XmlDecomposer.java
@@ -174,7 +174,7 @@ public class XmlDecomposer {
 		
 		// Transform the ExtendedAttributeText elements to separate XML elements.
 		if (decomposeConfig.formalizeExtendedAttributes()) {
-			nv = formalizeExtendedAttributesText(nv);
+			nv = formalizeExtendedAttributesText(nv, xmlFileContentsAndCharset);
 		}
 		
 		// Get the existing list of files in the decomposed model (if it exists). This is needed to track files which are written and which need to be deleted.
@@ -425,7 +425,7 @@ public class XmlDecomposer {
 		return xm.outputAndReparse();
 	}
 	
-	private VTDNav formalizeExtendedAttributesText(VTDNav nv) throws Exception {
+	private VTDNav formalizeExtendedAttributesText(VTDNav nv, FileContentAndCharset xmlFileContentsAndCharset) throws Exception {
 		logger.info("Formalizing extended attributes in document...");
 		
 		// We are going to replace all ExtnededAttributeText elements with it's formal representation, so we need an XmlModifier.
@@ -446,9 +446,7 @@ public class XmlDecomposer {
 			// The found token should be a starting tag.
 			if (nv.getTokenType(extAttrsTextNodeIndex) == VTDNav.TOKEN_STARTING_TAG) {
 				// Get the extended attribute text.
-				// Replace LF with CRLF, since VTD-Nav removes the carriage returns in the file (and PowerDesigner always has CRLF).
 				int extendedAttributeTextIndex = nv.getText();
-				//String extendedAttributesText = nv.toString(extendedAttributeTextIndex).replace("\n", "\r\n");
 				String extendedAttributesText = new String(nv.getXML().getBytes(nv.getTokenOffset(extendedAttributeTextIndex), nv.getTokenLength(extendedAttributeTextIndex)));
 				// We unescape the XML characters here, so the length property in the extended attributes can be used (cause it doesn't account for escaped XML characters).
 				extendedAttributesText = XMLUtils.unescapeXMLChars(extendedAttributesText);
@@ -465,7 +463,8 @@ public class XmlDecomposer {
 				Pattern extensionExtAttrsPattern = Pattern.compile(extAttrRegex);
 				Matcher extExtAttrsMatcher = extensionExtAttrsPattern.matcher(extendedAttributesText);
 				StringBuffer extExtAttrsXml = new StringBuffer();
-				extExtAttrsXml.append("\r\n<ExtendedAttributes>");
+				extExtAttrsXml.append(xmlFileContentsAndCharset.getLineSeparator());
+				extExtAttrsXml.append("<ExtendedAttributes>");
 				int currentExtensionExtAttrEnd = -1;
 				while (extExtAttrsMatcher.find()) {
 					String guid = extExtAttrsMatcher.group(1);
@@ -488,14 +487,16 @@ public class XmlDecomposer {
 					// If we reached the end of a previous extension list, we update the end to -1 so this match is handled as a OriginatingExtension.
 					if (currentExtensionExtAttrEnd != -1 && extAttrStart >= currentExtensionExtAttrEnd) {
 						logger.fine("The new match is outside of the extension section, so resetting end index.");
-						extExtAttrsXml.append("\r\n</OriginatingExtension>");
+						extExtAttrsXml.append(xmlFileContentsAndCharset.getLineSeparator());
+						extExtAttrsXml.append("</OriginatingExtension>");
 						currentExtensionExtAttrEnd = -1;
 					}
 					
 					// If we outside of a extension attribute list, a new extension part is started.
 					if (currentExtensionExtAttrEnd == -1) {
 						logger.fine(String.format("Found extention [ObjectID=%s;Name=%s;Length=%d;Content='%s'", guid, name, extAttrLength, extExtAttrContent));
-						extExtAttrsXml.append(String.format("\r\n<OriginatingExtension ObjectID=\"%s\" Name=\"%s\">", guid, name));
+						extExtAttrsXml.append(xmlFileContentsAndCharset.getLineSeparator());
+						extExtAttrsXml.append(String.format("<OriginatingExtension ObjectID=\"%s\" Name=\"%s\">", guid, name));
 						// Now we have added the element for the OriginatingExtension, we need to loop over the matches within the content part of the extension extended attributes.
 						// For each extended attribute we find, we add a separate XML element.
 						// Update the end of the extension extended attribute list to the current one. This way in the next loop we know we are handling an extended attribute part.
@@ -504,16 +505,19 @@ public class XmlDecomposer {
 					// We are inside a extension section, so we treat the match as an extended attribute within the extension.
 					else {
 						logger.fine(String.format("Found extended attributes [ObjectID=%s;Name=%s;Length=%d;Value='%s'", guid, name, extAttrLength, extExtAttrContent));
-						extExtAttrsXml.append(String.format("\r\n<ExtendedAttribute ObjectID=\"%s\" Name=\"%s\">%s</ExtendedAttribute>", guid, name, extExtAttrContent));
+						extExtAttrsXml.append(xmlFileContentsAndCharset.getLineSeparator());
+						extExtAttrsXml.append(String.format("<ExtendedAttribute ObjectID=\"%s\" Name=\"%s\">%s</ExtendedAttribute>", guid, name, extExtAttrContent));
 						// Update the region to scan to after the current extended attribute.
 						extExtAttrsMatcher.region(extAttrsEnd, extExtAttrsMatcher.regionEnd());
 					}
 				}
 				// If we exited the while loop and the end index is not -1, we need to add the ending tag of the extension element.
 				if (currentExtensionExtAttrEnd != -1) {
-					extExtAttrsXml.append("\r\n</OriginatingExtension>");
+					extExtAttrsXml.append(xmlFileContentsAndCharset.getLineSeparator());
+					extExtAttrsXml.append("</OriginatingExtension>");
 				}
-				extExtAttrsXml.append("\r\n</ExtendedAttributes>");
+				extExtAttrsXml.append(xmlFileContentsAndCharset.getLineSeparator());
+				extExtAttrsXml.append("</ExtendedAttributes>");
 				xm.insertAfterElement(extExtAttrsXml.toString());
 				// Now we added the replacement of the textual extended attributes, we can remove the ExtendedAttributesText element.
 				xm.remove(nv.expandWhiteSpaces(nv.getElementFragment(), VTDNav.WS_LEADING));

--- a/PowerDeComposer/src/main/java/com/xbreeze/xml/utils/FileContentAndCharset.java
+++ b/PowerDeComposer/src/main/java/com/xbreeze/xml/utils/FileContentAndCharset.java
@@ -1,10 +1,14 @@
 package com.xbreeze.xml.utils;
 
 import java.nio.charset.Charset;
+import java.util.logging.Logger;
 
 public class FileContentAndCharset {
+	private static final Logger logger = Logger.getGlobal();
+	
 	private String _fileContents;
 	private Charset _fileCharset;
+	private String _lineSeparator;
 	
 	public FileContentAndCharset(String fileContents, Charset fileCharset) {
 		this._fileContents = fileContents;
@@ -12,11 +16,36 @@ public class FileContentAndCharset {
 	}
 
 	public String getFileContents() {
-		return _fileContents;
+		return this._fileContents;
 	}
 
 	public Charset getFileCharset() {
-		return _fileCharset;
+		return this._fileCharset;
+	}
+	
+	/**
+	 * Get the line separator of the file.
+	 * @return The line separator for the file.
+	 * @throws Exception If the line separator can't be found and exception is thrown.
+	 */
+	public String getLineSeparator() throws Exception {
+		// If the line separator is not set yet, derive it from the file contents.
+		if (this._lineSeparator == null) {
+			// Find the first line-feed character.
+			int firstNewLineIndex = this._fileContents.indexOf('\n');
+			
+			if (firstNewLineIndex == -1)
+				throw new Exception("Cannot detect line separator. No line-feed character found in file!");
+			
+			// Check whether there is a carriage return before the line-feed character.
+			if (this._fileContents.charAt(firstNewLineIndex - 1) == '\r') {
+				this._lineSeparator = "\r\n";				
+			} else {
+				this._lineSeparator = "\n";
+			}
+			logger.fine(String.format("Found line separator: %s", this._lineSeparator.replace("\n", "[LF]").replace("\r", "[CR]")));
+		}
+		return this._lineSeparator;
 	}
 	
 	public byte[] getBytes() {

--- a/PowerDeComposer/src/main/java/com/xbreeze/xml/utils/XMLUtils.java
+++ b/PowerDeComposer/src/main/java/com/xbreeze/xml/utils/XMLUtils.java
@@ -29,6 +29,8 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.text.StringEscapeUtils;
+
 import com.ximpleware.AutoPilot;
 import com.ximpleware.ModifyException;
 import com.ximpleware.NavException;
@@ -49,8 +51,17 @@ public class XMLUtils {
 	 * @param input The text to escape.
 	 * @return The escaped input.
 	 */
-	public static String excapeXMLChars(String input) {
-		return input.replaceAll("\\<", "&lt;").replaceAll("\\>", "&gt;");
+	public static String escapeXMLChars(String input) {
+		return StringEscapeUtils.escapeXml10(input);
+	}
+	
+	/**
+	 * Unescape XML characters.
+	 * @param input The xml input with escaped XML.
+	 * @return The xml with unescaped chars.
+	 */
+	public static String unescapeXMLChars(String input) {
+		return StringEscapeUtils.unescapeXml(input);
 	}
 	
 	/**

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/charset/SpecialCharacters.feature
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/charset/SpecialCharacters.feature
@@ -3,7 +3,7 @@
 Feature: Special characters
   Here we test whether PowerDeComposer can handle special characters correctly.
   
-  Scenario: Special charachter in file
+  Scenario: Special character in file
     Given the composed file:
       """
       <?xml version="1.0" encoding="UTF-8"?>

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/ExitCode.feature
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/ExitCode.feature
@@ -1,0 +1,21 @@
+@Unit
+Feature: Compose Exit Code
+  Here we test the exit code while composing
+
+  Scenario: Succesfull exit code
+    Given the decomposed file:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <RootElement/>
+      """
+    When I perform a compose in separate process
+    Then I expect exit code 0
+
+  Scenario: Unsuccesfull exit code
+    Given the decomposed file:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <RootElement>
+      """
+    When I perform a compose in separate process
+    Then I expect exit code 1

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/ExtendedAttributes.feature
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/ExtendedAttributes.feature
@@ -69,3 +69,32 @@ Feature: Compose Extended Attributes
       </ChildElement>
       </RootElement>
       """
+  
+  Scenario: Compose extended attribute with special characters
+    Given the decomposed file:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <RootElement>
+      <ChildElement>
+      <ExtendedAttributes>
+      <OriginatingExtension ObjectID="4202E4F4-4187-47CE-83BE-51088F229451" Name="TestExtension">
+      <ExtendedAttribute ObjectID="38253E88-8698-4A5B-8398-0FA2B14556C0" Name="SqlExpression">-- Special characters: &lt;, &gt;, &amp;, &apos;, &quot;, ´, ~, !
+      @AMOUNT &gt; 100</ExtendedAttribute>
+      </OriginatingExtension>
+      </ExtendedAttributes>
+      </ChildElement>
+      </RootElement>
+      """
+    When I perform a compose
+    Then I expect a composed file with the following content:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <RootElement>
+      <ChildElement>
+      <a:ExtendedAttributesText>{4202E4F4-4187-47CE-83BE-51088F229451},TestExtension,118={38253E88-8698-4A5B-8398-0FA2B14556C0},SqlExpression,60=-- Special characters: &lt;, &gt;, &amp;, &apos;, &quot;, ´, ~, !
+      @AMOUNT &gt; 100
+      
+      </a:ExtendedAttributesText>
+      </ChildElement>
+      </RootElement>
+      """

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling.feature
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling.feature
@@ -1,4 +1,4 @@
-@Unit @Debug
+@Unit
 
 Feature: Compose New Line Handling
   Here we test whether PowerDeComposer Compose can handle different newline characters correctly.

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling.feature
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling.feature
@@ -1,4 +1,4 @@
-@Unit
+@Unit @Debug
 
 Feature: Compose New Line Handling
   Here we test whether PowerDeComposer Compose can handle different newline characters correctly.

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling/CRLF_handling/Composed/ExpectedComposedFile.xml
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling/CRLF_handling/Composed/ExpectedComposedFile.xml
@@ -2,6 +2,10 @@
 <RootElement>
 <ChildElements>
 <ChildElement id="FirstId">
+<a:ExtendedAttributesText>{4202E4F4-4187-47CE-83BE-51088F229451},TestExtension,107={38253E88-8698-4A5B-8398-0FA2B14556C0},SqlExpression,49=-- Extended attribute with newline
+@AMOUNT &gt; 100
+
+</a:ExtendedAttributesText>
 	<Name>FirstName</Name>
 </ChildElement>
 </ChildElements>

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling/CRLF_handling/Decomposed/IncludedFile.xml
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling/CRLF_handling/Decomposed/IncludedFile.xml
@@ -1,3 +1,9 @@
 <ChildElement id="FirstId">
+    <ExtendedAttributes>
+      <OriginatingExtension ObjectID="4202E4F4-4187-47CE-83BE-51088F229451" Name="TestExtension">
+        <ExtendedAttribute ObjectID="38253E88-8698-4A5B-8398-0FA2B14556C0" Name="SqlExpression">-- Extended attribute with newline
+@AMOUNT &gt; 100</ExtendedAttribute>
+      </OriginatingExtension>
+    </ExtendedAttributes>
 	<Name>FirstName</Name>
 </ChildElement>

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling/LF_handling/Composed/ExpectedComposedFile.xml
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling/LF_handling/Composed/ExpectedComposedFile.xml
@@ -2,7 +2,7 @@
 <RootElement>
 <ChildElements>
 <ChildElement id="FirstId">
-<a:ExtendedAttributesText>{4202E4F4-4187-47CE-83BE-51088F229451},TestExtension,106={38253E88-8698-4A5B-8398-0FA2B14556C0},SqlExpression,48=-- Extended attribute with newline
+<a:ExtendedAttributesText>{4202E4F4-4187-47CE-83BE-51088F229451},TestExtension,104={38253E88-8698-4A5B-8398-0FA2B14556C0},SqlExpression,48=-- Extended attribute with newline
 @AMOUNT &gt; 100
 
 </a:ExtendedAttributesText>

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling/LF_handling/Composed/ExpectedComposedFile.xml
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling/LF_handling/Composed/ExpectedComposedFile.xml
@@ -2,6 +2,10 @@
 <RootElement>
 <ChildElements>
 <ChildElement id="FirstId">
+<a:ExtendedAttributesText>{4202E4F4-4187-47CE-83BE-51088F229451},TestExtension,106={38253E88-8698-4A5B-8398-0FA2B14556C0},SqlExpression,48=-- Extended attribute with newline
+@AMOUNT &gt; 100
+
+</a:ExtendedAttributesText>
 	<Name>FirstName</Name>
 </ChildElement>
 </ChildElements>

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling/LF_handling/Decomposed/IncludedFile.xml
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/compose/NewLineHandling/LF_handling/Decomposed/IncludedFile.xml
@@ -1,3 +1,9 @@
 <ChildElement id="FirstId">
+    <ExtendedAttributes>
+      <OriginatingExtension ObjectID="4202E4F4-4187-47CE-83BE-51088F229451" Name="TestExtension">
+        <ExtendedAttribute ObjectID="38253E88-8698-4A5B-8398-0FA2B14556C0" Name="SqlExpression">-- Extended attribute with newline
+@AMOUNT &gt; 100</ExtendedAttribute>
+      </OriginatingExtension>
+    </ExtendedAttributes>
 	<Name>FirstName</Name>
 </ChildElement>

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/ExtendedAttributes.feature
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/ExtendedAttributes.feature
@@ -165,13 +165,15 @@ Feature: Decompose Extended Attributes
       <?xml version="1.0" encoding="UTF-8"?>
       <RootElement>
       <ChildElement>
-      <a:ExtendedAttributesText>{4202E4F4-4187-47CE-83BE-51088F229451},TestExtension,71={38253E88-8698-4A5B-8398-0FA2B14556C0},SqlExpression,13=@AMOUNT &gt; 100
+      <a:ExtendedAttributesText>{4202E4F4-4187-47CE-83BE-51088F229451},TestExtension,118={38253E88-8698-4A5B-8398-0FA2B14556C0},SqlExpression,60=-- Special characters: &lt;, &gt;, &amp;, &#39;, &quot;, ´, ~, !
+      @AMOUNT &gt; 100
       
       </a:ExtendedAttributesText>
       </ChildElement>
       </RootElement>
       """
     When I perform a decompose
+    # NOTE: The &#39; will be translated into a &apos;, since this is the standard (and more readable).
     Then I expect a decomposed file with the following content:
       """
       <?xml version="1.0" encoding="UTF-8"?>
@@ -179,7 +181,8 @@ Feature: Decompose Extended Attributes
       <ChildElement>
       <ExtendedAttributes>
       <OriginatingExtension ObjectID="4202E4F4-4187-47CE-83BE-51088F229451" Name="TestExtension">
-      <ExtendedAttribute ObjectID="38253E88-8698-4A5B-8398-0FA2B14556C0" Name="SqlExpression">@AMOUNT &gt; 100</ExtendedAttribute>
+      <ExtendedAttribute ObjectID="38253E88-8698-4A5B-8398-0FA2B14556C0" Name="SqlExpression">-- Special characters: &lt;, &gt;, &amp;, &apos;, &quot;, ´, ~, !
+      @AMOUNT &gt; 100</ExtendedAttribute>
       </OriginatingExtension>
       </ExtendedAttributes>
       </ChildElement>

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/ExtendedAttributes.feature
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/ExtendedAttributes.feature
@@ -150,7 +150,6 @@ Feature: Decompose Extended Attributes
       </RootElement>
       """
 
-  @Debug
   Scenario: Formalize extended attributes with XML chars
   	Given the config file:
       """

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/ExtendedAttributes.feature
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/ExtendedAttributes.feature
@@ -149,3 +149,40 @@ Feature: Decompose Extended Attributes
       </ChildElement>
       </RootElement>
       """
+
+  @Debug
+  Scenario: Formalize extended attributes with XML chars
+  	Given the config file:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <PowerDeComposerConfig>
+      	<Decompose>
+      		<DecomposableElement />
+      	</Decompose>
+      </PowerDeComposerConfig>
+      """
+    And the composed file:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <RootElement>
+      <ChildElement>
+      <a:ExtendedAttributesText>{4202E4F4-4187-47CE-83BE-51088F229451},TestExtension,71={38253E88-8698-4A5B-8398-0FA2B14556C0},SqlExpression,13=@AMOUNT &gt; 100
+      
+      </a:ExtendedAttributesText>
+      </ChildElement>
+      </RootElement>
+      """
+    When I perform a decompose
+    Then I expect a decomposed file with the following content:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <RootElement>
+      <ChildElement>
+      <ExtendedAttributes>
+      <OriginatingExtension ObjectID="4202E4F4-4187-47CE-83BE-51088F229451" Name="TestExtension">
+      <ExtendedAttribute ObjectID="38253E88-8698-4A5B-8398-0FA2B14556C0" Name="SqlExpression">@AMOUNT &gt; 100</ExtendedAttribute>
+      </OriginatingExtension>
+      </ExtendedAttributes>
+      </ChildElement>
+      </RootElement>
+      """

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling.feature
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling.feature
@@ -1,4 +1,4 @@
-@Unit @Debug
+@Unit
 
 Feature: Decompose New Line Handling
   Here we test whether PowerDeComposer Decompose can handle different newline characters correctly.

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling.feature
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling.feature
@@ -1,4 +1,4 @@
-@Unit
+@Unit @Debug
 
 Feature: Decompose New Line Handling
   Here we test whether PowerDeComposer Decompose can handle different newline characters correctly.

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling/CRLF_handling/Composed/ComposedFile.xml
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling/CRLF_handling/Composed/ComposedFile.xml
@@ -2,6 +2,10 @@
 <RootElement>
 <ChildElements>
 <ChildElement id="FirstId">
+<a:ExtendedAttributesText>{4202E4F4-4187-47CE-83BE-51088F229451},TestExtension,107={38253E88-8698-4A5B-8398-0FA2B14556C0},SqlExpression,49=-- Extended attribute with newline
+@AMOUNT &gt; 100
+
+</a:ExtendedAttributesText>
 	<Name>FirstName</Name>
 </ChildElement>
 </ChildElements>

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling/CRLF_handling/Decomposed/ChildElements/FirstId.xml
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling/CRLF_handling/Decomposed/ChildElements/FirstId.xml
@@ -1,3 +1,9 @@
 <ChildElement id="FirstId">
+<ExtendedAttributes>
+<OriginatingExtension ObjectID="4202E4F4-4187-47CE-83BE-51088F229451" Name="TestExtension">
+<ExtendedAttribute ObjectID="38253E88-8698-4A5B-8398-0FA2B14556C0" Name="SqlExpression">-- Extended attribute with newline
+@AMOUNT &gt; 100</ExtendedAttribute>
+</OriginatingExtension>
+</ExtendedAttributes>
 	<Name>FirstName</Name>
 </ChildElement>

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling/LF_handling/Composed/ComposedFile.xml
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling/LF_handling/Composed/ComposedFile.xml
@@ -2,7 +2,7 @@
 <RootElement>
 <ChildElements>
 <ChildElement id="FirstId">
-<a:ExtendedAttributesText>{4202E4F4-4187-47CE-83BE-51088F229451},TestExtension,106={38253E88-8698-4A5B-8398-0FA2B14556C0},SqlExpression,48=-- Extended attribute with newline
+<a:ExtendedAttributesText>{4202E4F4-4187-47CE-83BE-51088F229451},TestExtension,104={38253E88-8698-4A5B-8398-0FA2B14556C0},SqlExpression,48=-- Extended attribute with newline
 @AMOUNT &gt; 100
 
 </a:ExtendedAttributesText>

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling/LF_handling/Composed/ComposedFile.xml
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling/LF_handling/Composed/ComposedFile.xml
@@ -2,6 +2,10 @@
 <RootElement>
 <ChildElements>
 <ChildElement id="FirstId">
+<a:ExtendedAttributesText>{4202E4F4-4187-47CE-83BE-51088F229451},TestExtension,106={38253E88-8698-4A5B-8398-0FA2B14556C0},SqlExpression,48=-- Extended attribute with newline
+@AMOUNT &gt; 100
+
+</a:ExtendedAttributesText>
 	<Name>FirstName</Name>
 </ChildElement>
 </ChildElements>

--- a/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling/LF_handling/Decomposed/ChildElements/FirstId.xml
+++ b/PowerDeComposer/src/test/resources/com/xbreeze/xml/test/decompose/NewLineHandling/LF_handling/Decomposed/ChildElements/FirstId.xml
@@ -1,3 +1,9 @@
 <ChildElement id="FirstId">
+<ExtendedAttributes>
+<OriginatingExtension ObjectID="4202E4F4-4187-47CE-83BE-51088F229451" Name="TestExtension">
+<ExtendedAttribute ObjectID="38253E88-8698-4A5B-8398-0FA2B14556C0" Name="SqlExpression">-- Extended attribute with newline
+@AMOUNT &gt; 100</ExtendedAttribute>
+</OriginatingExtension>
+</ExtendedAttributes>
 	<Name>FirstName</Name>
 </ChildElement>


### PR DESCRIPTION
- Fixed encoded XML chars issue while decomposing and composing.
- Fixed incorrect usage of CRLF when formalizing and deformalizing extended attributes (should now also be in line-ending of original file).
- Added setting exit code to 1 when something went wrong while running PowerDeComposer.